### PR TITLE
대회 문제페이지 남은시간 퍼블리싱 수정

### DIFF
--- a/src/pages/room/ui/Contest/Question/index.tsx
+++ b/src/pages/room/ui/Contest/Question/index.tsx
@@ -34,7 +34,6 @@ export const ContestQuestion = () => {
       try {
         const res: Contest = await contestProblem(parseInt(contestId, 10));
         setContestDetail(res);
-        console.log(res);
       } catch (err: any) {
         if (err.response) {
           setErrorCode(err.response.data.code);

--- a/src/pages/room/ui/Contest/Question/style.ts
+++ b/src/pages/room/ui/Contest/Question/style.ts
@@ -19,7 +19,6 @@ export const Button = styled.div`
   right: 0;
 `;
 export const RemainingTimeContainer = styled.div`
-  padding: 56px 370px 103px 370px;
   position: relative;
   border: 1px solid transparent;
   border-radius: 8px;
@@ -28,6 +27,8 @@ export const RemainingTimeContainer = styled.div`
   box-sizing: border-box;
   width: auto;
   ${flex.COLUMN_CENTER}
+  padding-bottom: 40px;
+  padding-top: 56px;
 
   &:before {
     content: "";
@@ -50,7 +51,7 @@ export const Time = styled.div`
 `;
 export const Line = styled.div`
   border-top: 1px solid ${theme.grey300};
-  width: 100%;
+  width: 60%;
 `;
 export const ButtonRank = styled.div`
   padding-top: 31px;


### PR DESCRIPTION
## 💡 개요
대회 문제페이지 남은시간 퍼블리싱하였습니다.
## 📃 작업내용
RemainingTimeContainer에 있는 좌,우 패딩을 삭제하고 상,하 패딩만 추가
## 🔀 변경사항
room/ui/Contest/Question/style.ts
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/38a01600-72c1-479a-92da-cb50628a36ed)
