### PR TITLE
랭킹페이지 height 설정 및 코드에디터 height 설정

### DIFF
--- a/src/pages/game/ui/editor/index.tsx
+++ b/src/pages/game/ui/editor/index.tsx
@@ -123,8 +123,8 @@ export const CodeEditor = () => {
 
   useEffect(() => {
     const updateEditorHeight = () => {
-      const newHeight = window.innerHeight * 0.45;
-      setEditorHeight(`${newHeight}px`);
+      const newHeight = window.innerHeight * 0.06;
+      setEditorHeight(`${newHeight}vh`);
     };
 
     updateEditorHeight();

--- a/src/pages/room/ui/contestRank/style.ts
+++ b/src/pages/room/ui/contestRank/style.ts
@@ -10,11 +10,12 @@ interface RankColorProps {
 
 export const Layout = styled.div`
   width: 100%;
+  min-height: 100vh;
   ${flex.HORIZONTAL}
   position: relative;
 `;
 export const Content = styled.div`
-  ${flex.COLUMN_CENTER}
+  ${flex.COLUMN_VERTICAL}
   gap: 3.75rem;
   padding-top: 6.25rem;
   margin-bottom: 12rem;


### PR DESCRIPTION
## 💡 개요
랭킹페이지와 코드에디터에 height 오류가 있었다
## 📃 작업내용
랭킹페이지는 min-height를 주었고 코드에디터에는 vh 속성을 주어 해결하였다.
## 🔀 변경사항
pages/game/ui/editer/index.tsx 수정
pages/room/ui/contestRank/style.ts 수정
## 📸 스크린샷
전
![image](https://github.com/user-attachments/assets/81cb8311-c393-4520-bfee-53850926d9b8)
후
![image](https://github.com/user-attachments/assets/95f52025-5f15-45d4-8ae9-aa32f1ef9461)
