### PR TITLE
사파리 폰트 안됨 이슈 해결

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,8 +20,14 @@ code {
 
 @font-face {
   font-family: "NEXONFootballGothicBA1";
-  src: url("https://gcore.jsdelivr.net/gh/projectnoonnu/noonfonts_20-04@2.1/NEXONFootballGothicBA1.woff")
-    format("woff");
+  src: url("https://gcore.jsdelivr.net/gh/projectnoonnu/noonfonts_20-04@2.1/NEXONFootballGothicBA1.woff") format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Pretendard-Regular';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
## 💡 개요
사파리 웹브라우저에서 프리텐다드 폰트 적용이 안되는 이슈를 발견했습니다.

## 📃 작업내용
프리텐다드 폰트를 css 최상위 파일에 정의해줘서 해결했습니다.

## 🔀 변경사항

## 📸 스크린샷
<img width="1710" alt="스크린샷 2024-10-04 오후 11 35 47" src="https://github.com/user-attachments/assets/73b8112c-8a43-45f9-a297-ff6d12f42ccc">
