### PR TITLE
랭킹 채점기준 퍼블리싱 및 랭킹페이지 퍼블리싱 수정

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react-scripts:
         specifier: 5.0.1
         version: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5)
+      react-split:
+        specifier: ^2.0.14
+        version: 2.0.14(react@18.3.1)
       sockjs-client:
         specifier: ^1.6.1
         version: 1.6.1
@@ -5195,6 +5198,11 @@ packages:
       typescript:
         optional: true
 
+  react-split@2.0.14:
+    resolution: {integrity: sha512-bKWydgMgaKTg/2JGQnaJPg51T6dmumTWZppFgEbbY0Fbme0F5TuatAScCLaqommbGQQf/ZT1zaejuPDriscISA==}
+    peerDependencies:
+      react: '*'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -5541,6 +5549,9 @@ packages:
   spdy@4.0.2:
     resolution: {integrity: sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==}
     engines: {node: '>=6.0.0'}
+
+  split.js@1.6.5:
+    resolution: {integrity: sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -12323,6 +12334,12 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
+  react-split@2.0.14(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      react: 18.3.1
+      split.js: 1.6.5
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -12713,6 +12730,8 @@ snapshots:
       spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
+
+  split.js@1.6.5: {}
 
   sprintf-js@1.0.3: {}
 

--- a/src/assets/CircleExit.svg
+++ b/src/assets/CircleExit.svg
@@ -1,0 +1,6 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 107">
+<circle id="Ellipse 12" cx="7" cy="7" r="7" fill="#E33434"/>
+<path id="Vector" d="M10.0065 4L4 10M4 4L10.0065 10" stroke="#811212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/pages/room/ui/contestRank/index.tsx
+++ b/src/pages/room/ui/contestRank/index.tsx
@@ -6,6 +6,7 @@ import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/shared/components";
 import { Loading } from "@/pages/loading";
 import * as S from "./style";
+import { Buttons } from "./style";
 
 interface ProblemStatuses {
   status: string;
@@ -69,16 +70,13 @@ export const ContestRank = () => {
   }, [contestId]);
   return rankedPlayers.length ? (
     <S.Layout>
-      <S.BlueBg>
-        <GameRankBlue />
-      </S.BlueBg>
-      <S.GreyBg>
-        <GameRankGrey />
-      </S.GreyBg>
       <S.Content>
         <S.TitleLayout>
           <S.Title>{title}</S.Title>
-          <S.ExitButton>
+          <S.Buttons>
+            <Button mode="small" color="gray" font="pretendard">
+              채점기준
+            </Button>
             <Button
               mode="small"
               color="red"
@@ -87,7 +85,7 @@ export const ContestRank = () => {
             >
               나가기
             </Button>
-          </S.ExitButton>
+          </S.Buttons>
         </S.TitleLayout>
         <S.Chart>
           <S.Attribute>

--- a/src/pages/room/ui/contestRank/index.tsx
+++ b/src/pages/room/ui/contestRank/index.tsx
@@ -4,6 +4,7 @@ import GameRankGrey from "@/assets/GameRankGrey";
 import { gameRakingList } from "@/pages/room/api/roomApi";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/shared/components";
+import { Loading } from "@/pages/loading";
 import * as S from "./style";
 
 interface ProblemStatuses {
@@ -151,6 +152,6 @@ export const ContestRank = () => {
       </S.Content>
     </S.Layout>
   ) : (
-    <div>Loading...</div>
+    <Loading />
   );
 };

--- a/src/pages/room/ui/contestRank/index.tsx
+++ b/src/pages/room/ui/contestRank/index.tsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from "react";
-import GameRankBlue from "@/assets/GameRankBlue";
-import GameRankGrey from "@/assets/GameRankGrey";
 import { gameRakingList } from "@/pages/room/api/roomApi";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/shared/components";
 import { Loading } from "@/pages/loading";
+import ScoreStandard from "@/shared/components/ScoreStandard";
 import * as S from "./style";
-import { Buttons } from "./style";
 
 interface ProblemStatuses {
   status: string;
@@ -22,6 +20,7 @@ export const ContestRank = () => {
   const navigate = useNavigate();
   const [playerDetail, setPlayerDetail] = useState<Player[]>([]);
   const [rankedPlayers, setRankedPlayers] = useState<Player[][]>([]);
+  const [isStandardShow, setIsStandardShow] = useState<boolean>(false);
   const { contestId } = useParams<{ contestId: string }>();
   const location = useLocation();
   const params = new URLSearchParams(location.search);
@@ -74,7 +73,12 @@ export const ContestRank = () => {
         <S.TitleLayout>
           <S.Title>{title}</S.Title>
           <S.Buttons>
-            <Button mode="small" color="gray" font="pretendard">
+            <Button
+              mode="small"
+              color="gray"
+              font="pretendard"
+              onClick={() => setIsStandardShow(true)}
+            >
               채점기준
             </Button>
             <Button
@@ -148,6 +152,9 @@ export const ContestRank = () => {
           </S.RankingLayout>
         </S.Chart>
       </S.Content>
+      {isStandardShow && (
+        <ScoreStandard setIsStandardShow={setIsStandardShow} />
+      )}
     </S.Layout>
   ) : (
     <Loading />

--- a/src/pages/room/ui/contestRank/style.ts
+++ b/src/pages/room/ui/contestRank/style.ts
@@ -17,20 +17,10 @@ export const Layout = styled.div`
 export const Content = styled.div`
   ${flex.COLUMN_VERTICAL}
   gap: 3.75rem;
-  padding-top: 4.5rem;
+  padding-top: 60px;
   margin-bottom: 12rem;
   position: relative;
-`;
-export const BlueBg = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-`;
-export const GreyBg = styled.div`
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 607px;
+  width: 100%;
 `;
 export const Title = styled.p`
   ${Pretendard.Title}
@@ -139,7 +129,13 @@ export const QuestionSolveRank = styled.p`
 `;
 export const TitleLayout = styled.div`
   width: 100%;
-  ${flex.COLUMN_CENTER};
-  gap: 12px;
+  ${flex.CENTER};
+  background-color: #f7f7f7;
+  padding: 24px 0;
 `;
-export const ExitButton = styled.div``;
+export const Buttons = styled.div`
+  position: absolute;
+  right: 7.5rem;
+  ${flex.CENTER};
+  gap: 0.25rem;
+`;

--- a/src/pages/room/ui/contestRank/style.ts
+++ b/src/pages/room/ui/contestRank/style.ts
@@ -17,7 +17,7 @@ export const Layout = styled.div`
 export const Content = styled.div`
   ${flex.COLUMN_VERTICAL}
   gap: 3.75rem;
-  padding-top: 60px;
+  padding-top: 52px;
   margin-bottom: 12rem;
   position: relative;
   width: 100%;
@@ -130,7 +130,7 @@ export const QuestionSolveRank = styled.p`
 export const TitleLayout = styled.div`
   width: 100%;
   ${flex.CENTER};
-  background-color: #f7f7f7;
+  background-color: ${theme.grey100};
   padding: 24px 0;
 `;
 export const Buttons = styled.div`

--- a/src/pages/room/ui/contestRank/style.ts
+++ b/src/pages/room/ui/contestRank/style.ts
@@ -17,7 +17,7 @@ export const Layout = styled.div`
 export const Content = styled.div`
   ${flex.COLUMN_VERTICAL}
   gap: 3.75rem;
-  padding-top: 6.25rem;
+  padding-top: 4.5rem;
   margin-bottom: 12rem;
   position: relative;
 `;
@@ -139,9 +139,7 @@ export const QuestionSolveRank = styled.p`
 `;
 export const TitleLayout = styled.div`
   width: 100%;
-  ${flex.CENTER};
-`
-export const ExitButton = styled.div`
-  position: absolute;
-  right: 0;
-`
+  ${flex.COLUMN_CENTER};
+  gap: 12px;
+`;
+export const ExitButton = styled.div``;

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled, { css } from "styled-components";
-import { NexonFont, Pretendard, theme } from "../style";
+import { flex, NexonFont, Pretendard, theme } from "../style";
 
 type ButtonMode = "big" | "exit" | "small" | "choose" | "warn";
 type ColorMode =
@@ -111,13 +111,17 @@ const ButtonType = (mode: ButtonMode, color: ColorMode, font?: FontType) => {
         return font === "nexon"
           ? css`
               width: auto;
-              padding: 7px 16px;
+              padding: 0 16px;
+              height: 32px;
               ${NexonFont.NexonSmallText}
+              ${flex.CENTER};
             `
           : css`
               width: auto;
-              padding: 7px 16px;
+              padding: 0 16px;
+              height: 32px;
               ${Pretendard.SmallText}
+              ${flex.CENTER};
             `;
       case "choose":
         return css`

--- a/src/shared/components/ScoreStandard/index.tsx
+++ b/src/shared/components/ScoreStandard/index.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import exitCircleIcon from "@/assets/CircleExit.svg";
+import * as S from "./style";
+
+interface ScoreStandardProps {
+  setIsStandardShow: (value: boolean) => void;
+}
+
+const ScoreStandard = ({ setIsStandardShow }: ScoreStandardProps) => (
+  <S.StandardLayout>
+    <S.ModalLayout>
+      <S.ExitCircle
+        src={exitCircleIcon}
+        onClick={() => setIsStandardShow(false)}
+      />
+      <S.Standard>채점 기준</S.Standard>
+      <S.ContentBox>
+        <S.Content>
+          <S.Topics>
+            <S.Texts>
+              <S.TopicTitle>문제 해결 수</S.TopicTitle>
+              <S.TopicContents>
+                <S.TopicContent>참가자가 해결한 문제의 개수가</S.TopicContent>
+                <S.TopicContent>
+                  <S.BlueColor>가장 중요한 순위 결정 요소</S.BlueColor>입니다.
+                </S.TopicContent>
+              </S.TopicContents>
+            </S.Texts>
+            <S.Texts>
+              <S.TopicTitle>패널티</S.TopicTitle>
+              <S.TopicContents>
+                <S.TopicContent>문제 해결 수가 동일한 경우,</S.TopicContent>
+                <S.TopicContent>
+                  <S.BlueColor>
+                    페널티가 적은 참가자가 상위 순위를 차지
+                  </S.BlueColor>
+                  합니다.
+                </S.TopicContent>
+              </S.TopicContents>
+            </S.Texts>
+            <S.Texts>
+              <S.TopicTitle>실패한 문제</S.TopicTitle>
+              <S.TopicContents>
+                <S.TopicContent>
+                  실패(failed) 상태인 문제는 점수가
+                </S.TopicContent>
+                <S.TopicContent>
+                  부여되지 않으며 순위 산정에서 제외됩니다.
+                </S.TopicContent>
+              </S.TopicContents>
+              <S.TopicContent>
+                실패한 문제에 대한{" "}
+                <S.BlueColor>추가 페널티는 부여되지 않습니다.</S.BlueColor>
+              </S.TopicContent>
+            </S.Texts>
+          </S.Topics>
+        </S.Content>
+        <S.CenterLine />
+        <S.Content>
+          <S.Topics>
+            <S.Texts>
+              <S.TopicTitle>실격</S.TopicTitle>
+              <S.TopicContents>
+                <S.TopicContent>
+                  부정행위 등으로 실격 처리된 경우,
+                </S.TopicContent>
+                <S.TopicContent>
+                  해당 참가자는 모든 점수가 0점 처리되며
+                </S.TopicContent>
+                <S.TopicContent>
+                  <S.RedColor>순위에서 제외</S.RedColor>됩니다.
+                </S.TopicContent>
+              </S.TopicContents>
+            </S.Texts>
+          </S.Topics>
+        </S.Content>
+      </S.ContentBox>
+      <S.Background />
+      <S.Background isSecond />
+    </S.ModalLayout>
+  </S.StandardLayout>
+);
+
+export default ScoreStandard;

--- a/src/shared/components/ScoreStandard/style.ts
+++ b/src/shared/components/ScoreStandard/style.ts
@@ -88,4 +88,5 @@ export const ExitCircle = styled.img`
   position: absolute;
   right: 7px;
   top: 7px;
+  cursor: pointer;
 `;

--- a/src/shared/components/ScoreStandard/style.ts
+++ b/src/shared/components/ScoreStandard/style.ts
@@ -1,0 +1,91 @@
+import styled from "styled-components";
+import { flex, NexonFont, theme } from "@/shared/style";
+
+export const StandardLayout = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.2);
+  ${flex.CENTER};
+`;
+export const ModalLayout = styled.div`
+  width: 57.5rem;
+  height: 36.5rem;
+  background-color: ${theme.white};
+  box-shadow:
+    -368px 361px 144px 0 rgba(0, 0, 0, 0),
+    -235px 231px 132px 0 rgba(0, 0, 0, 0.01),
+    -132px 130px 111px 0 rgba(0, 0, 0, 0.04),
+    -59px 58px 82px 0 rgba(0, 0, 0, 0.07),
+    -15px 14px 45px 0 rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+  ${flex.COLUMN_VERTICAL};
+  position: relative;
+  overflow: hidden;
+`;
+export const Standard = styled.p`
+  margin-top: 20px;
+  ${NexonFont.NexonSmallTitle};
+  color: ${theme.grey900};
+  margin-bottom: 20px;
+  z-index: 2;
+`;
+export const ContentBox = styled.div`
+  ${flex.CENTER};
+  z-index: 2;
+`;
+export const Content = styled.div`
+  width: 460px;
+  height: 450px;
+  ${flex.CENTER};
+`;
+export const CenterLine = styled.div`
+  width: 1px;
+  height: 420px;
+  background-color: ${theme.grey300};
+`;
+export const Topics = styled.div`
+  ${flex.COLUMN_CENTER};
+  gap: 40px;
+`;
+export const Texts = styled.div`
+  ${flex.COLUMN_CENTER};
+  gap: 20px;
+`;
+export const TopicTitle = styled.p`
+  ${NexonFont.NexonBigText};
+  font-weight: 700;
+  color: ${theme.grey900};
+`;
+export const TopicContent = styled.p`
+  ${NexonFont.NexonText};
+  font-weight: 300;
+  color: ${theme.grey800};
+`;
+export const TopicContents = styled.div`
+  ${flex.COLUMN_CENTER};
+`;
+export const BlueColor = styled.span`
+  color: ${theme.insertBlue};
+`;
+export const RedColor = styled.span`
+  color: ${theme.warningRed};
+`;
+export const Background = styled.div<{ isSecond?: boolean }>`
+  width: 458px;
+  height: 458px;
+  border-radius: 458px;
+  position: absolute;
+  background: ${({ isSecond }) =>
+    isSecond
+      ? "radial-gradient(50% 50% at 50% 50%, #ff9f9f 0%, #fff 100%)"
+      : "radial-gradient(50% 50% at 50% 50%, #9fceff 0%, #fff 100%)"};
+  left: ${({ isSecond }) => (isSecond ? "auto" : "-28%")};
+  right: ${({ isSecond }) => (isSecond ? "-28%" : "auto")};
+  top: ${({ isSecond }) => (isSecond ? "42%" : "-4%")};
+`;
+export const ExitCircle = styled.img`
+  position: absolute;
+  right: 7px;
+  top: 7px;
+`;


### PR DESCRIPTION
## 💡 개요
랭킹 채점기준을 모달로 띄우고, 랭킹페이지의 배경을 제거하였습니다.
## 📃 작업내용
useState를 사용해 모달 관리
## 🔀 변경사항
pages/room/ui/contestRank 수정
components/scoreStandard 추가
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/540cdebf-2106-4546-bd77-c89aff62c6f6)
![image](https://github.com/user-attachments/assets/93a1be2a-c356-453f-b37f-f4d25ce46706)