### PR TITLE
터미널에 실행 결과값이 계단 형식으로 뜨는 이슈 해결

### DIFF
--- a/src/pages/game/ui/editor/index.tsx
+++ b/src/pages/game/ui/editor/index.tsx
@@ -104,8 +104,6 @@ export const CodeEditor = () => {
     disconnectWebSocket,
   } = useWebSocket();
 
-  console.log(consoleOutput);
-
   const [executionActive, setExecutionActive] = useState(isExecutionActive);
 
   const [submitStatus, setSubmitStatus] = useState<

--- a/src/pages/game/ui/testbox/index.tsx
+++ b/src/pages/game/ui/testbox/index.tsx
@@ -41,12 +41,22 @@ export const TestBox = forwardRef<TestBoxHandles, TestBoxProps>(
     const inputDisableRef = useRef(isInputDisabled);
     const { initializeTerminal, resetAndEnableTerminal, writeToTerminal } =
       useTerminal();
-    const previousOutputRef = useRef<string>(""); // 이전 출력 저장
+    const previousOutputRef = useRef<string>("");
 
     useEffect(() => {
       if (consoleOutput && consoleOutput !== previousOutputRef.current) {
-        const newOutput = consoleOutput.slice(previousOutputRef.current.length);
-        writeToTerminal(newOutput);
+        let newOutput;
+        if (previousOutputRef.current.length > consoleOutput.length) {
+          newOutput = consoleOutput;
+        } else {
+          newOutput = consoleOutput.slice(previousOutputRef.current.length);
+        }
+
+        if (newOutput.trim() !== "") {
+          writeToTerminal(newOutput);
+        } else {
+          console.error("빈 메시지 수신: 출력할 내용이 없습니다.");
+        }
         previousOutputRef.current = consoleOutput;
       }
     }, [consoleOutput, writeToTerminal]);

--- a/src/pages/game/ui/testbox/index.tsx
+++ b/src/pages/game/ui/testbox/index.tsx
@@ -107,6 +107,7 @@ export const TestBox = forwardRef<TestBoxHandles, TestBoxProps>(
           `${translateVerdict(testCase.verdict)}\n${testCase.output}`,
       )
       .join("\n");
+
     useEffect(() => {
       inputDisableRef.current = isInputDisabled;
     }, [isInputDisabled]);
@@ -158,7 +159,7 @@ export const TestBox = forwardRef<TestBoxHandles, TestBoxProps>(
                 ref={terminalRef}
                 style={{
                   width: "100%",
-                  height: "fit-content",
+                  height: "50vh",
                   backgroundColor: "#000",
                   marginTop: "10px",
                 }}

--- a/src/shared/hooks/useTerminal.ts
+++ b/src/shared/hooks/useTerminal.ts
@@ -78,8 +78,7 @@ export const useTerminal = () => {
 
   const writeToTerminal = (output: string) => {
     if (terminalInstanceRef.current) {
-      terminalInstanceRef.current.writeln(output);
-      disconnectWebSocket();
+      terminalInstanceRef.current.write(`${output}\r`);
     }
   };
 

--- a/src/shared/hooks/useTerminal.ts
+++ b/src/shared/hooks/useTerminal.ts
@@ -78,7 +78,12 @@ export const useTerminal = () => {
 
   const writeToTerminal = (output: string) => {
     if (terminalInstanceRef.current) {
-      terminalInstanceRef.current.write(`${output}\r`);
+      const lines = output.split("\n");
+      lines.forEach((line) => {
+        if (line.trim() !== "") {
+          terminalInstanceRef.current?.write(`${line}\n\r`);
+        }
+      });
     }
   };
 

--- a/src/shared/hooks/useTerminal.ts
+++ b/src/shared/hooks/useTerminal.ts
@@ -10,9 +10,10 @@ interface TerminalProps {
 }
 
 export const useTerminal = () => {
-  const { disconnectWebSocket } = useWebSocket();
+  const { connectWebSocket, clientRef } = useWebSocket();
   const terminalInstanceRef = useRef<Terminal | null>(null);
   const inputBufferRef = useRef<string>("");
+  const isTerminalInitialized = useRef(false);
 
   const initializeTerminal = ({
     terminalRef,
@@ -55,6 +56,11 @@ export const useTerminal = () => {
       });
 
       terminalInstanceRef.current = terminal;
+      isTerminalInitialized.current = true;
+
+      if (!clientRef.current) {
+        connectWebSocket();
+      }
     }
   };
 
@@ -67,6 +73,7 @@ export const useTerminal = () => {
     if (terminalInstanceRef.current) {
       terminalInstanceRef.current.dispose();
       terminalInstanceRef.current = null;
+      isTerminalInitialized.current = false;
       initializeTerminal({
         terminalRef,
         inputDisableRef,
@@ -84,6 +91,8 @@ export const useTerminal = () => {
           terminalInstanceRef.current?.write(`${line}\n\r`);
         }
       });
+    } else {
+      console.error("터미널 인스턴스 없음");
     }
   };
 

--- a/src/shared/hooks/useWebSocket.ts
+++ b/src/shared/hooks/useWebSocket.ts
@@ -4,21 +4,18 @@ import SockJS from "sockjs-client";
 import { customAxios } from "../utils/customAxios";
 
 export const useWebSocket = () => {
-  const [consoleOutput, setConsoleOutput] = useState<string>(""); // 콘솔 출력 상태
-  const [isExecutionActive, setIsExecutionActive] = useState<boolean>(false); // WebSocket 실행 상태
-  const clientRef = useRef<Client | null>(null); // WebSocket 클라이언트
-  const sessionIdRef = useRef<string | null>(null); // 세션 ID 저장
-  const isSubscribedRef = useRef<boolean>(false); // 중복 구독 방지 플래그
-  const processingRef = useRef<boolean>(false); // 메시지 처리 중인지 확인하는 플래그
+  const [consoleOutput, setConsoleOutput] = useState<string>("");
+  const [isExecutionActive, setIsExecutionActive] = useState<boolean>(false);
+  const clientRef = useRef<Client | null>(null); 
+  const sessionIdRef = useRef<string | null>(null); 
+  const isSubscribedRef = useRef<boolean>(false); 
+  const processingRef = useRef<boolean>(false); 
 
-  // 메시지 큐에서 하나씩 처리하는 함수
   const processMessage = (message: string) => {
     const trimmedMessage = message.trimStart();
     setConsoleOutput((prevOutput) => `${prevOutput}${trimmedMessage}\n`);
-    console.log(trimmedMessage);
   };
 
-  // WebSocket 연결 함수
   const connectWebSocket = async () =>
     new Promise<void>((resolve, reject) => {
       const { baseURL } = customAxios.defaults;
@@ -35,12 +32,9 @@ export const useWebSocket = () => {
             const response = await customAxios.get(`/execution`);
             const sessionId = response.data;
             sessionIdRef.current = sessionId;
-            console.log("Session ID:", sessionId);
-            setConsoleOutput(""); // 콘솔 출력 초기화
-            // 중복 구독 방지
+            setConsoleOutput("");
             if (!isSubscribedRef.current) {
               isSubscribedRef.current = true;
-              // 메시지 수신 시 메시지 처리
               stompClient.subscribe(
                 `/topic/output/${sessionId}`,
                 (message: IMessage) => {
@@ -48,7 +42,6 @@ export const useWebSocket = () => {
                 },
               );
 
-              // 에러 메시지 처리
               stompClient.subscribe(
                 `/topic/error/${sessionId}`,
                 (message: IMessage) => {
@@ -59,7 +52,7 @@ export const useWebSocket = () => {
                 },
               );
             }
-            resolve(); // 세션 ID를 받아온 후에 웹소켓 연결 완료로 처리
+            resolve();
           } catch (error) {
             console.error("Error fetching session ID:", error);
             reject(error);
@@ -70,27 +63,27 @@ export const useWebSocket = () => {
           reject(frame.body);
         },
       });
-      stompClient.activate(); // WebSocket 클라이언트 활성화
-      clientRef.current = stompClient; // 클라이언트 참조 저장
+      stompClient.activate();
+      clientRef.current = stompClient;
     });
-  // WebSocket 연결 해제 함수
+  
   const disconnectWebSocket = () => {
     if (clientRef.current) {
-      clientRef.current.deactivate(); // WebSocket 연결 해제
-      setConsoleOutput(""); // 콘솔 출력 상태 초기화
+      clientRef.current.deactivate();
+      setConsoleOutput("");
     }
-    setIsExecutionActive(false); // WebSocket 실행 상태 비활성화
-    isSubscribedRef.current = false; // 구독 플래그 초기화
-    processingRef.current = false; // 메시지 처리 플래그 초기화
+    setIsExecutionActive(false);
+    isSubscribedRef.current = false;
+    processingRef.current = false;
   };
   return {
-    clientRef, // WebSocket 클라이언트 참조 반환
-    sessionIdRef, // 세션 ID 참조 반환
-    consoleOutput, // 콘솔 출력 상태 반환
-    isExecutionActive, // WebSocket 실행 상태 반환
-    setConsoleOutput, // 콘솔 출력 상태 설정 함수 반환
-    setIsExecutionActive, // WebSocket 실행 상태 설정 함수 반환
-    connectWebSocket, // WebSocket 연결 함수 반환
-    disconnectWebSocket, // WebSocket 연결 해제 함수 반환
+    clientRef,
+    sessionIdRef,
+    consoleOutput,
+    isExecutionActive, 
+    setConsoleOutput,
+    setIsExecutionActive,
+    connectWebSocket,
+    disconnectWebSocket,
   };
 };


### PR DESCRIPTION
## 💡 개요
터미널에 실행 결과값이 계단 형식으로 뜨는 이슈 해결했습니다.

## 📃 작업내용
서버에서 줄바꿈이(\n) 포함되어 메세지가 넘어오지만, 줄바꿈 이후 커서가 줄의 처음으로 이동하지 않기 때문에 일어난 이슈.
커서는 줄의 끝 부분에서 시작하게 되고, 그 결과 줄이 오른쪽으로 밀리면서 계단형식으로 보이게 되는것.
-> 결과 메세지를 줄 단위로 분리시켜 각 줄의 끝에 커서 이동(\r)을 추가해 해결함.

## 🔀 변경사항

## 📸 스크린샷
<img width="1710" alt="스크린샷 2024-10-12 오후 11 31 01" src="https://github.com/user-attachments/assets/dd3b6f8b-e99d-4395-92b6-ea3c08486356">

