### PR TITLE
아이템전 게임 화면 나가기 버튼 제거

### DIFF
--- a/src/pages/game/ui/index.tsx
+++ b/src/pages/game/ui/index.tsx
@@ -242,7 +242,11 @@ export const Game = () => {
           </>
         )}
 
-        <GameHeader problemsCount={problemsCount} problemIndex={problemIndex} />
+        <GameHeader
+          problemsCount={problemsCount}
+          problemIndex={problemIndex}
+          noHeader={!roomId}
+        />
         <Split
           sizes={[50, 50]}
           minSize={200}

--- a/src/shared/components/GameHeader/index.tsx
+++ b/src/shared/components/GameHeader/index.tsx
@@ -10,6 +10,7 @@ import * as S from "./style";
 interface gameHeaderProps {
   problemsCount: number;
   problemIndex: number;
+  noHeader?: boolean;
 }
 
 interface problemsType {
@@ -25,7 +26,11 @@ interface ContestDetails {
   endTime: string;
 }
 
-const GameHeader = ({ problemsCount, problemIndex }: gameHeaderProps) => {
+const GameHeader = ({
+  problemsCount,
+  problemIndex,
+  noHeader = false,
+}: gameHeaderProps) => {
   const { pathname } = window.location;
   const navigate = useNavigate();
   const segments = pathname.split("/");
@@ -159,9 +164,11 @@ const GameHeader = ({ problemsCount, problemIndex }: gameHeaderProps) => {
       </S.ClockContainer>
       <S.Setting>
         <S.LineContainer>{/* <S.Line /> */}</S.LineContainer>
-        <Button mode="small" color="red" font="nexon" onClick={handleExit}>
-          나가기
-        </Button>
+        {noHeader && (
+          <Button mode="small" color="red" font="nexon" onClick={handleExit}>
+            나가기
+          </Button>
+        )}
       </S.Setting>
     </S.Layout>
   );


### PR DESCRIPTION
## 💡 개요
아이템전 게임 화면에 나가기 버튼을 제거했습니다.

## 📃 작업내용
GameHeader에 noHeader props를 추가해 Game에 roomId가 있다면 나가기 버튼이 제거되도록 했습니다.

## 🔀 변경사항

## 📸 스크린샷
대회 게임화면
<img width="1706" alt="스크린샷 2024-11-11 오후 8 20 00" src="https://github.com/user-attachments/assets/772044df-5a7c-4ee1-acf0-5eaecad5efed">

아이템전 게임화면
<img width="1709" alt="스크린샷 2024-11-11 오후 8 22 42" src="https://github.com/user-attachments/assets/1c0690c3-6dfd-45e3-988a-568c0b405a76">
