### PR TITLE
아이템 경고 색상 진하게

### DIFF
--- a/src/shared/components/Item/warning/index.tsx
+++ b/src/shared/components/Item/warning/index.tsx
@@ -22,9 +22,10 @@ const Layout = styled.div`
   top: 0;
   animation: ${blinkAnimation} 0.4s ease-in-out 0s 5;
   background: radial-gradient(
-      81.38% 81.38% at 50% 50%,
-      rgba(227, 52, 52, 0.00) 0%,
-      rgba(227, 52, 52, 0.15) 100%);
+    81.38% 81.38% at 50% 50%,
+    rgba(227, 52, 52, 0) 0%,
+    rgba(227, 52, 52, 0.3) 100%
+  );
   animation-fill-mode: forwards;
   pointer-events: none;
 `;


### PR DESCRIPTION
## 💡 개요
아이템이 오기전 경고의 색상을 더 진하게 하였습니다.
## 📃 작업내용
경고의 스타일을 수정
## 🔀 변경사항
shared/components/item/warning 수정
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/349ecf67-2050-41f4-9047-996128099335)
