### PR TITLE
코드에디터 공백 삭제

### DIFF
--- a/src/pages/game/ui/index.tsx
+++ b/src/pages/game/ui/index.tsx
@@ -305,18 +305,8 @@ export const Game = () => {
           sizes={[50, 50]}
           minSize={200}
           expandToMin={false}
-          gutterSize={10}
-          gutterAlign="center"
+          gutterSize={0}
           direction="horizontal"
-          cursor="col-resize"
-          gutter={(direction) => {
-            const gutter = document.createElement("div");
-            gutter.className = `gutter gutter-${direction}`;
-            gutter.onmouseenter = () => {
-              gutter.style.cursor = "col-resize";
-            };
-            return gutter;
-          }}
           style={{ display: "flex", width: "100%", height: "100%" }}
         >
           <ProblemWrapper>


### PR DESCRIPTION
## 💡 개요
코드에디터 옆에있던 공백을 삭제하였습니다
## 📃 작업내용
react-split 속성에 들어가있던 gutter의 너비를 0px로 주었습니다
## 🔀 변경사항
pages/game/ui/index.tsx
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/40625ecf-f8e7-4ae7-b7b9-744363af3ad0)
