### PR TITLE
미러미러 방어실패 추가

### DIFF
--- a/src/pages/game/ui/index.tsx
+++ b/src/pages/game/ui/index.tsx
@@ -9,7 +9,7 @@ import ItemIconList from "@/shared/components/ItemIconList";
 import { useGameInfo } from "@/shared/hooks/useGameInfo";
 import OctopusInk from "@/shared/components/Item/octopusInk";
 import Shield from "@/shared/components/Item/shield";
-import { RotatableContainer } from "@/shared/components/Item/Mirror";
+import { RotatableAnimation } from "@/shared/components/Item/Mirror";
 import Devil from "@/shared/components/Item/devil";
 import WaterBalloon from "@/shared/components/Item/waterBalloon";
 import { CodeEditor } from "./editor";
@@ -44,13 +44,6 @@ export const GameLayout = styled.div<{
   overflow: hidden;
   pointer-events: ${({ isWaterBalloonVisible, isShieldActive }) =>
     isWaterBalloonVisible && !isShieldActive ? "none" : "auto"};
-`;
-
-export const GameBox = styled.div`
-  ${flex.HORIZONTAL}
-  position: fixed;
-  width: 100%;
-  height: 100%;
 `;
 
 export const ProblemWrapper = styled.div`
@@ -289,7 +282,7 @@ export const Game = () => {
       isWaterBalloonVisible={isWaterBalloonVisible}
       isShieldActive={isShieldActive}
     >
-      <RotatableContainer rotationState={rotationState}>
+      <RotatableAnimation rotationState={rotationState}>
         {isItemAnimation &&
           !isShieldActive &&
           attackInfo?.targetUser === userId && (
@@ -308,7 +301,7 @@ export const Game = () => {
                 attackInfo?.item === "MIRROR" &&
                 isVisible && (
                   <OverlayItem isInkVisible={isVisible}>
-                    <RotatableContainer
+                    <RotatableAnimation
                       rotationState={rotationState}
                       onAnimationComplete={handleAnimationComplete}
                     />
@@ -380,7 +373,7 @@ export const Game = () => {
             />
           </ItemListWrapper>
         </Split>
-      </RotatableContainer>
+      </RotatableAnimation>
 
       {isShieldActive && (
         <OverlayItem isInkVisible={isVisible}>

--- a/src/shared/components/Item/Mirror.tsx
+++ b/src/shared/components/Item/Mirror.tsx
@@ -1,5 +1,16 @@
-import { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import styled, { keyframes, css } from "styled-components";
+import ItemStatusText from "@/shared/components/ItemStatusText";
+
+const NoShieldText = styled.div`
+  position: fixed;
+  top: 30%;
+  left: 81%;
+  transition:
+    opacity 0.6s ease,
+    transform 0.6s ease;
+  z-index: 999;
+`;
 
 const rotate180Animation = keyframes`
   from {
@@ -8,9 +19,9 @@ const rotate180Animation = keyframes`
   to {
     transform: rotate(180deg);
   }
-`;
+  `;
 
-const rotateBackToOriginalAnimation = keyframes`
+  const rotateBackToOriginalAnimation = keyframes`
   from {
     transform: rotate(180deg);
   }
@@ -21,7 +32,6 @@ const rotateBackToOriginalAnimation = keyframes`
 
 export const RotatableContainer = styled.div<{
   rotationState: "none" | "first" | "second";
-  onAnimationComplete?: () => void;
 }>`
   perspective: 1000px;
   width: 100%;
@@ -40,16 +50,32 @@ export const RotatableContainer = styled.div<{
     `}
 `;
 
-const RotatableContainerWithAnimation = ({
+export const RotatableAnimation = ({
   rotationState,
   onAnimationComplete,
   children,
 }: {
   rotationState: "none" | "first" | "second";
   onAnimationComplete?: () => void;
-  // eslint-disable-next-line no-undef
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }) => {
+  const [textVisible, setTextVisible] = useState(false);
+  const [textTranslate, setTextTranslate] = useState(0);
+
+  useEffect(() => {
+    if (rotationState === "first") {
+      setTextVisible(true);
+      setTextTranslate(-30);
+
+      setTimeout(() => {
+        setTextTranslate(40);
+        setTimeout(() => {
+          setTextVisible(false);
+        }, 600);
+      }, 800);
+    }
+  }, [rotationState]);
+
   useEffect(() => {
     const handleAnimationEnd = () => {
       if (onAnimationComplete) {
@@ -66,13 +92,24 @@ const RotatableContainerWithAnimation = ({
   }, [rotationState, onAnimationComplete]);
 
   return (
-    <RotatableContainer
-      className="rotatable-container"
-      rotationState={rotationState}
-    >
-      {children}
-    </RotatableContainer>
+    <>
+      {textVisible && (
+        <NoShieldText
+          style={{
+            transform: `translateY(${textTranslate}px)`,
+            opacity: textVisible ? 1 : 0,
+            transition: "transform 0.6s ease, opacity 0.6s ease",
+          }}
+        >
+          <ItemStatusText status="방어 실패" title="미러미러" />
+        </NoShieldText>
+      )}
+      <RotatableContainer
+        className="rotatable-container"
+        rotationState={rotationState}
+      >
+        {children}
+      </RotatableContainer>
+    </>
   );
 };
-
-export default RotatableContainerWithAnimation;


### PR DESCRIPTION
## 💡 개요
미러미러 아이템에 방어실패 아이콘을 추가하였습니다
## 📃 작업내용
미러미러가 화면을 돌아가게 하여, 아이콘은 화면 밖으로 빼서 고정시켰습니다.
## 🔀 변경사항
components/Items/Mirror.tsx
## 📸 스크린샷
![image](https://github.com/user-attachments/assets/9f2d0930-9597-4cbf-9717-b02fee46c48a)
