### PR TITLE
미러미러 실행중일때 다른 아이템 들어오면 같이 실행됨 이슈해결

### DIFF
--- a/src/pages/game/ui/index.tsx
+++ b/src/pages/game/ui/index.tsx
@@ -274,6 +274,7 @@ export const Game = () => {
         setTimeout(() => {
           setRotationState("none");
           setIsMirrorOpen(false);
+          handleAnimationComplete();
         }, 4000);
       }, 5000);
     }
@@ -321,10 +322,7 @@ export const Game = () => {
                 attackInfo?.item === "MIRROR" &&
                 isVisible && (
                   <OverlayItem isInkVisible={isVisible}>
-                    <RotatableAnimation
-                      rotationState={rotationState}
-                      onAnimationComplete={handleAnimationComplete}
-                    />
+                    <RotatableAnimation rotationState={rotationState} />
                   </OverlayItem>
                 )}
               {!isShieldActive &&


### PR DESCRIPTION
## 💡 개요
미러미러 실행중일때 다른 아이템 들어오면 같이 실행됨 이슈해결

## 📃 작업내용
미러미러 180도 회전 후 다시 원래 모습으로 돌아왔을때 handleAnimationComplete(아이템 끝났을때 호출하는 함수) 함수 호출

## 🔀 변경사항

## 📸 스크린샷
