### PR TITLE
미러미러 공격 이후에 너무 늦게 다른 아이템이 실행됨 이슈 해결

### DIFF
--- a/src/pages/game/ui/index.tsx
+++ b/src/pages/game/ui/index.tsx
@@ -165,6 +165,7 @@ export const Game = () => {
 
         setIsShieldActive(true);
         setIsWaterBalloonVisible(false);
+        refreshItemList();
 
         isItemAnimation.current = false;
         setAttackInfo(null);
@@ -287,9 +288,11 @@ export const Game = () => {
       setTimeout(() => {
         setRotationState("second");
         setTimeout(() => {
+          handleAnimationComplete();
+        }, 1000);
+        setTimeout(() => {
           setRotationState("none");
           setIsMirrorOpen(false);
-          handleAnimationComplete();
         }, 4000);
       }, 5000);
     }


### PR DESCRIPTION
## 💡 개요
미러미러 공격 이후에 너무 늦게 다른 아이템이 실행되는 이슈를 해결했습니다.

## 📃 작업내용
미러미러 실행 후 원래 화면으로 돌아온 후 1초 뒤 아이템 실행을 끝마치는 함수를 호출했습니다.

## 🔀 변경사항
방어에 성공한 후 refreshItemList함수를 호출해 가지고있는 사용한 아이템이 없어지도록 수정했습니다.

## 📸 스크린샷
