### PR TITLE
문어먹물이 실행되고 다음 아이템이 대기하고 있다면 문어먹물이 마지막에 줄어들지 않음 이슈 해결

### DIFF
--- a/src/shared/components/Item/octopusInk/index.tsx
+++ b/src/shared/components/Item/octopusInk/index.tsx
@@ -41,11 +41,13 @@ const OctopusInk = ({
 
       setTimeout(() => {
         setShrink(true);
+        setTimeout(() => {
+          onAnimationComplete();
+        }, 1000);
       }, 4000);
 
       setTimeout(() => {
         setTextHidden(true);
-        onAnimationComplete();
       }, 1600);
     }
   }, [visibleLogos, onAnimationComplete]);


### PR DESCRIPTION
## 💡 개요
문어먹물이 실행되고 다음 아이템이 대기하고 있다면 문어먹물이 마지막에 줄어들지 않음 이슈 해결

## 📃 작업내용
문어 먹물 애니메이션이 끝난 1초후 onAnimationComplete함수(아이템 종료 애니메이션)를 호출했습니다. 

## 🔀 변경사항

## 📸 스크린샷
