### PR TITLE
코드저장 안됨, 다른 방 코드 안뜨게 수정

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 6.24.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-scripts:
         specifier: 5.0.1
-        version: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5)
+        version: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5)
       react-split:
         specifier: ^2.0.14
         version: 2.0.14(react@18.3.1)
@@ -113,7 +113,7 @@ importers:
         version: 7.24.7(@babel/core@7.25.2)
       '@craco/craco':
         specifier: ^7.1.0
-        version: 7.1.0(@types/node@22.5.5)(postcss@8.4.39)(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5))(typescript@4.9.5)
+        version: 7.1.0(@types/node@22.5.5)(postcss@8.4.39)(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5))(typescript@4.9.5)
       '@eslint/js':
         specifier: ^9.7.0
         version: 9.7.0
@@ -143,13 +143,13 @@ importers:
         version: 8.57.0
       eslint-config-airbnb:
         specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.9.0(eslint@8.57.0))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-react@7.35.0(eslint@8.57.0))(eslint@8.57.0)
+        version: 19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.9.0(eslint@8.57.0))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-react@7.35.0(eslint@8.57.0))(eslint@8.57.0)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@8.57.0)
       eslint-import-resolver-alias:
         specifier: ^1.1.2
-        version: 1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0))
+        version: 1.1.2(eslint-plugin-import@2.29.1)
       eslint-import-resolver-node:
         specifier: ^0.3.9
         version: 0.3.9
@@ -7422,14 +7422,14 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@craco/craco@7.1.0(@types/node@22.5.5)(postcss@8.4.39)(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5))(typescript@4.9.5)':
+  '@craco/craco@7.1.0(@types/node@22.5.5)(postcss@8.4.39)(react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5))(typescript@4.9.5)':
     dependencies:
       autoprefixer: 10.4.19(postcss@8.4.39)
       cosmiconfig: 7.1.0
       cosmiconfig-typescript-loader: 1.0.9(@types/node@22.5.5)(cosmiconfig@7.1.0)(typescript@4.9.5)
       cross-spawn: 7.0.3
       lodash: 4.17.21
-      react-scripts: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5)
+      react-scripts: 5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5)
       semver: 7.6.2
       webpack-merge: 5.10.0
     transitivePeerDependencies:
@@ -9672,7 +9672,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.57.0
@@ -9681,10 +9681,10 @@ snapshots:
       object.entries: 1.1.8
       semver: 6.3.1
 
-  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0))(eslint-plugin-jsx-a11y@6.9.0(eslint@8.57.0))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-react@7.35.0(eslint@8.57.0))(eslint@8.57.0):
+  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.29.1)(eslint-plugin-jsx-a11y@6.9.0(eslint@8.57.0))(eslint-plugin-react-hooks@4.6.2(eslint@8.57.0))(eslint-plugin-react@7.35.0(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
@@ -9696,7 +9696,7 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(jest@27.5.1(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5)))(typescript@4.9.5):
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)(jest@27.5.1(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5)))(typescript@4.9.5):
     dependencies:
       '@babel/core': 7.25.2
       '@babel/eslint-parser': 7.24.7(@babel/core@7.25.2)(eslint@8.57.0)
@@ -9723,7 +9723,7 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1):
     dependencies:
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
 
@@ -9740,7 +9740,7 @@ snapshots:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
@@ -9752,7 +9752,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -9781,7 +9781,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.14.0
       is-glob: 4.0.3
@@ -12275,7 +12275,7 @@ snapshots:
       '@remix-run/router': 1.17.1
       react: 18.3.1
 
-  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5):
+  react-scripts@5.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(@types/babel__core@7.20.5)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)(react@18.3.1)(sockjs-client@1.6.1)(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5))(type-fest@0.21.3)(typescript@4.9.5):
     dependencies:
       '@babel/core': 7.25.2
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.11.0)(sockjs-client@1.6.1)(type-fest@0.21.3)(webpack-dev-server@4.15.2(webpack@5.92.1))(webpack@5.92.1)
@@ -12293,7 +12293,7 @@ snapshots:
       dotenv: 10.0.0
       dotenv-expand: 5.1.0
       eslint: 8.57.0
-      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)(jest@27.5.1(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5)))(typescript@4.9.5)
+      eslint-config-react-app: 7.0.1(@babel/plugin-syntax-flow@7.24.7(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.25.2))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)(jest@27.5.1(ts-node@10.9.2(@types/node@22.5.5)(typescript@4.9.5)))(typescript@4.9.5)
       eslint-webpack-plugin: 3.2.0(eslint@8.57.0)(webpack@5.92.1)
       file-loader: 6.2.0(webpack@5.92.1)
       fs-extra: 10.1.0

--- a/src/pages/game/ui/editor/index.tsx
+++ b/src/pages/game/ui/editor/index.tsx
@@ -79,16 +79,23 @@ export const CodeEditor = ({
   useEffect(() => {
     if (contestId && problemId) {
       setIsContest(true);
-    } else {
+      console.log("대회");
+    } else if (contestId === undefined && problemId) {
       setIsContest(false);
+      console.log("방");
     }
-  }, []);
+  }, [contestId, problemId]);
 
   useEffect(() => {
-    const savedCode = isContest
-      ? localStorage.getItem(`code_${contestId}_${problemId}_${languages}`)
-      : localStorage.getItem(`code_${problemId}_${languages}`);
+    if (problemId === undefined) {
+      return;
+    }
 
+    const storageKey = contestId
+      ? `code_${contestId}_${problemId}_${languages}`
+      : `code_${problemId}_${languages}`;
+
+    const savedCode = localStorage.getItem(storageKey);
     if (savedCode) {
       setCode(savedCode);
     } else {
@@ -97,11 +104,6 @@ export const CodeEditor = ({
           const res = await boilerplateCode(languages);
           setBoilerplate(res);
           setCode(res);
-
-          const storageKey = isContest
-            ? `code_${contestId}_${problemId}_${languages}`
-            : `code_${problemId}`;
-
           localStorage.setItem(storageKey, res);
         } catch (err) {
           console.error(err);
@@ -126,9 +128,9 @@ export const CodeEditor = ({
       setBoilerplate(res);
       setCode(res);
       const resetKey = isContest
-      ? `code_${contestId}_${problemId}_${languages}`
-      : `code_${problemId}_${languages}_`;
-      localStorage.setItem(resetKey, res)
+        ? `code_${contestId}_${problemId}_${languages}`
+        : `code_${problemId}_${languages}_`;
+      localStorage.setItem(resetKey, res);
     } catch (err) {
       console.error(err);
     }

--- a/src/pages/game/ui/editor/index.tsx
+++ b/src/pages/game/ui/editor/index.tsx
@@ -79,10 +79,8 @@ export const CodeEditor = ({
   useEffect(() => {
     if (contestId && problemId) {
       setIsContest(true);
-      console.log("대회");
     } else if (contestId === undefined && problemId) {
       setIsContest(false);
-      console.log("방");
     }
   }, [contestId, problemId]);
 
@@ -106,7 +104,7 @@ export const CodeEditor = ({
           setCode(res);
           localStorage.setItem(storageKey, res);
         } catch (err) {
-          console.error(err);
+          /**/
         }
       })();
     }
@@ -132,7 +130,7 @@ export const CodeEditor = ({
         : `code_${problemId}_${languages}_`;
       localStorage.setItem(resetKey, res);
     } catch (err) {
-      console.error(err);
+      /**/
     }
   };
 
@@ -183,10 +181,10 @@ export const CodeEditor = ({
           }),
         });
       } else {
-        console.log("WebSocket client or session ID is not ready.");
+        /**/
       }
     } catch (err) {
-      console.error(err);
+      /**/
     } finally {
       setIsExecuteLoading(false);
     }

--- a/src/pages/result/ui/index.tsx
+++ b/src/pages/result/ui/index.tsx
@@ -29,6 +29,16 @@ export const Result = () => {
   const [roomTitle, setRoomTitle] = useAtom(roomTitleAtom);
 
   useEffect(() => {
+    const codePattern = /^code_\d+_[a-zA-Z]+$/; // code_숫자_언어 형식
+    Object.keys(localStorage).forEach((key) => {
+      if (codePattern.test(key)) {
+        console.log(`Deleting key: ${key}`); // 삭제 키 확인용
+        localStorage.removeItem(key);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
     const storedTitle = localStorage.getItem("roomTitle") || "게임 제목 없음";
     if (roomTitle === "게임 제목 없음") {
       setRoomTitle(storedTitle);

--- a/src/pages/result/ui/index.tsx
+++ b/src/pages/result/ui/index.tsx
@@ -29,10 +29,9 @@ export const Result = () => {
   const [roomTitle, setRoomTitle] = useAtom(roomTitleAtom);
 
   useEffect(() => {
-    const codePattern = /^code_\d+_[a-zA-Z]+$/; // code_숫자_언어 형식
+    const codePattern = /^code_\d+_[a-zA-Z]+$/;
     Object.keys(localStorage).forEach((key) => {
       if (codePattern.test(key)) {
-        console.log(`Deleting key: ${key}`); // 삭제 키 확인용
         localStorage.removeItem(key);
       }
     });
@@ -45,19 +44,16 @@ export const Result = () => {
     }
   }, [roomTitle, setRoomTitle]);
   useEffect(() => {
-    const fetchData = async () => {
+    (async () => {
       if (roomId) {
         try {
           const res = await getItemResult(roomId);
-          console.log("API 응답:", res);
           setItemRoomResult(res);
         } catch (err) {
-          console.error("API 오류:", err);
+          /**/
         }
       }
-    };
-
-    fetchData();
+    })();
   }, [roomId]);
 
   return (


### PR DESCRIPTION
## 💡 개요
대회의 코드저장이 안되고, 한 방에서 저장했던 코드가 다른방에서도 뜨는 이슈가 있었습니다.
## 📃 작업내용
대회의 코드저장은 contestId가 랜더링이 되기 전 저장된 코드를 가져오게 되어있어 모두 랜더링이 된 후, 코드를 가져오는 함수를 실행시켰습니다.
또한 저장했던 코드가 다른방에서도 뜨는 이슈는 로컬스토리지에 같은 키를 사용하기때문이였는데, 만약 이 에러를 다른 키를 사용하여 로컬스토리지에 저장하는 로직을 사용한다면 로컬스토리지에 수도없이 많은 키들이 생기기 때문에 게임이 끝났을 시 저장된 코드를 지우는것으로 해결하였습니다.
하지만 유저가 게임하는 도중에 게임을 나가는 예외에 대해서 처리를 해야할 것 같습니다.
## 🔀 변경사항
game/ui/editer 수정
result/ui 수정
## 📸 스크린샷

