### PR TITLE
방마다 코드저장 초기화 수정

### DIFF
--- a/src/pages/game/ui/editor/index.tsx
+++ b/src/pages/game/ui/editor/index.tsx
@@ -84,6 +84,11 @@ export const CodeEditor = ({
     }
   }, [contestId, problemId]);
 
+  const extractRoomId = (key: string): string | null => {
+    const match = key.match(/^room_([^_]+)_/);
+    return match ? match[1] : null;
+  };
+
   useEffect(() => {
     if (problemId === undefined) {
       return;
@@ -91,7 +96,20 @@ export const CodeEditor = ({
 
     const storageKey = contestId
       ? `code_${contestId}_${problemId}_${languages}`
-      : `code_${problemId}_${languages}`;
+      : `room_${roomId}_${problemId}_${languages}`;
+
+    if (!contestId) {
+      const keys = Object.keys(localStorage);
+
+      keys.forEach((key) => {
+        if (key.startsWith("room_")) {
+          const currentRoomId = extractRoomId(key);
+          if (currentRoomId !== roomId) {
+            localStorage.removeItem(key);
+          }
+        }
+      });
+    }
 
     const savedCode = localStorage.getItem(storageKey);
     if (savedCode) {
@@ -104,7 +122,7 @@ export const CodeEditor = ({
           setCode(res);
           localStorage.setItem(storageKey, res);
         } catch (err) {
-          /**/
+          console.error("Error fetching boilerplate code:", err);
         }
       })();
     }
@@ -115,7 +133,7 @@ export const CodeEditor = ({
       setCode(newCode);
       const changedKey = isContest
         ? `code_${contestId}_${problemId}_${languages}`
-        : `code_${problemId}_${languages}`;
+        : `room_${roomId}_${problemId}_${languages}`;
       localStorage.setItem(changedKey, newCode);
     }
   };
@@ -127,7 +145,7 @@ export const CodeEditor = ({
       setCode(res);
       const resetKey = isContest
         ? `code_${contestId}_${problemId}_${languages}`
-        : `code_${problemId}_${languages}_`;
+        : `room_${roomId}_${problemId}_${languages}`;
       localStorage.setItem(resetKey, res);
     } catch (err) {
       /**/
@@ -203,7 +221,7 @@ export const CodeEditor = ({
     if (isContest) {
       localStorage.setItem(`code_${contestId}_${problemId}_${languages}`, code);
     } else {
-      localStorage.setItem(`code_${problemId}_${languages}`, code);
+      localStorage.setItem(`room_${roomId}_${problemId}_${languages}`, code);
     }
     setIsModalOpen(true);
   };

--- a/src/pages/game/ui/index.tsx
+++ b/src/pages/game/ui/index.tsx
@@ -76,7 +76,10 @@ export const ModalLayout = styled.div`
 export const Game = () => {
   const [roomTitle, setRoomTitle] = useAtom(roomTitleAtom);
   const location = useLocation();
-  const newGameTitle = location.state?.title || "게임 제목 없음";
+  const newGameTitle =
+    location.state?.title ||
+    localStorage.getItem("roomTitle") ||
+    "게임 제목 없음";
 
   useEffect(() => {
     if (newGameTitle && roomTitle !== newGameTitle) {
@@ -84,10 +87,6 @@ export const Game = () => {
       localStorage.setItem("roomTitle", newGameTitle);
     }
   }, [newGameTitle, roomTitle, setRoomTitle]);
-
-  useEffect(() => {
-    console.log("현재 게임 제목:", roomTitle);
-  }, [roomTitle]);
 
   const { problemId, contestId, roomId } = useParams();
   const [problem, setProblem] = useState<problemInfoProps>({

--- a/src/pages/main/ui/page/Page.tsx
+++ b/src/pages/main/ui/page/Page.tsx
@@ -20,7 +20,6 @@ export const Main = () => {
   const handleModalClose = (value: number) => {
     if (value === 0) {
       setIsModalOpen(false);
-      navigate("/login");
     }
   };
 

--- a/src/pages/result/ui/index.tsx
+++ b/src/pages/result/ui/index.tsx
@@ -29,9 +29,9 @@ export const Result = () => {
   const [roomTitle, setRoomTitle] = useAtom(roomTitleAtom);
 
   useEffect(() => {
-    const codePattern = /^code_\d+_[a-zA-Z]+$/;
+    const roomPattern = /^room_/;
     Object.keys(localStorage).forEach((key) => {
-      if (codePattern.test(key)) {
+      if (roomPattern.test(key)) {
         localStorage.removeItem(key);
       }
     });

--- a/src/shared/components/MainHeader/index.tsx
+++ b/src/shared/components/MainHeader/index.tsx
@@ -24,7 +24,8 @@ const MainHeader = () => {
   const refreshToken = getCookie("refreshToken");
 
   const headerItemClick = (url: string, id: number) => {
-    if (id === 2 || id === 3) {
+    const navIds = [2, 3, 5];
+    if (navIds.includes(id)) {
       if (!isLogin) {
         setIsModalOpen(true);
         return;
@@ -46,7 +47,6 @@ const MainHeader = () => {
   const handleModalClose = (value: number) => {
     if (value === 0) {
       setIsModalOpen(false);
-      navigate("/login");
     }
   };
 

--- a/src/shared/components/MainHeader/index.tsx
+++ b/src/shared/components/MainHeader/index.tsx
@@ -78,7 +78,7 @@ const MainHeader = () => {
         <S.Details>
           <S.DetailText onClick={onNameClick}>
             {accessToken && refreshToken
-              ? localStorage.getItem("name")
+              ? getCookie("name")
               : "로그인"}
           </S.DetailText>
           |

--- a/src/shared/utils/auth/authService.ts
+++ b/src/shared/utils/auth/authService.ts
@@ -33,7 +33,7 @@ export const authorizeAccess = async (accessToken: String) => {
 
     if (getCookie("accessToken") && getCookie("refreshToken")) {
       const userData = await fetchUserData();
-      localStorage.setItem("name", userData.nickname);
+      setCookie("name", userData.nickname);
       localStorage.setItem("color", userData.color);
       window.location.replace("/");
     }


### PR DESCRIPTION
## 💡 개요
방마다 코드를 저장하는 로직을 수정하였습니다.
## 📃 작업내용
방마다 방의 uuid가 같으면 코드를 이어서 저장하고, 다르다면 코드를 삭제하여 저장된 코드가 다른방에서도 보이지 않게 하였습니다.
헤더에서 비로그인 시 아이템전을 들어가지 못하도록 하였습니다
사용자의 이름을 쿠키에서 저장하였습니다.
## 🔀 변경사항
game/ui/editer
components/mainHeader
## 📸 스크린샷
