### PR TITLE
물풍선 터질 때 화면 멈춤 이슈

### DIFF
--- a/src/pages/game/ui/index.tsx
+++ b/src/pages/game/ui/index.tsx
@@ -301,6 +301,7 @@ export const Game = () => {
   useEffect(() => {
     if (isWaterBalloonVisible && codeEditorRef.current) {
       codeEditorRef.current.blur();
+      closeModal();
     }
   }, [isWaterBalloonVisible]);
 


### PR DESCRIPTION
## 💡 개요
물풍선이 터짐과 동시에 공격 대상 클릭시 화면이 멈추는 에러를 해결했습니다.

## 📃 작업내용
만약 물풍선이 터졌을 때 공격이 멈추면  공격 모달을 없애도록 했습니다.

## 🔀 변경사항

## 📸 스크린샷
